### PR TITLE
Add workflow to auto-rebase single-commit PRs

### DIFF
--- a/.github/workflows/auto-rebase-merge.yml
+++ b/.github/workflows/auto-rebase-merge.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Check and enable auto-merge with rebase
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         commit_count=$(gh pr view "$PR_NUMBER" --json commits -q '.commits | length')

--- a/.github/workflows/auto-rebase-merge.yml
+++ b/.github/workflows/auto-rebase-merge.yml
@@ -2,9 +2,7 @@ name: Auto-rebase merge single-commit PRs
 
 on:
   pull_request:
-    types:
-    - opened
-    - synchronize
+    types: [opened, synchronize]
 
 permissions:
   contents: write

--- a/.github/workflows/auto-rebase-merge.yml
+++ b/.github/workflows/auto-rebase-merge.yml
@@ -1,0 +1,27 @@
+name: Auto-rebase merge single-commit PRs
+
+on:
+  pull_request:
+    types:
+    - opened
+    - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check and enable auto-merge with rebase
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        commit_count=$(gh pr view "$PR_NUMBER" --json commits -q '.commits | length')
+
+        if test "$commit_count" -eq 1; then
+          gh pr merge "$PR_NUMBER" --rebase --auto
+          echo "Enabled auto-merge with rebase for single-commit PR"
+        fi


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that enables auto-merge with rebase for single-commit PRs
- Multi-commit PRs will use the default merge commit strategy

Configure the repo:

    gh repo edit --enable-auto-merge
    gh repo edit --enable-merge-commit

Generated with [Claude Code](https://claude.com/claude-code)